### PR TITLE
feat(*): make the observable resubscribable and fail properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "homepage": "https://github.com/mrtnbroder/superagent-rxjs#readme",
   "dependencies": {
+    "ramda": "^0.22.1",
     "rxjs": "^5.0.0-beta.0",
     "superagent": "^2.0.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -2,17 +2,53 @@
 
 import type { Observable } from 'rxjs'
 import { Observable as O } from 'rxjs/Observable'
+import pick from 'ramda/src/pick'
 
-const observify = function(): Observable<*> {
+const observify = (Request) => function (): Observable<*> {
   return O.create((o) => {
-    this.end((err, res) => {
+    const requestCallback = (err, res) => {
       if (err) {
         o.error(err)
       } else {
         o.next(res)
+        o.complete()
       }
-      o.complete()
-    })
+    }
+
+    /*
+     * Superagent requests can only be made (`.end()`) once. Since Rx observables
+     * must be resubscribable, we create a new superagent instance if create is
+     * called more than once.
+     */
+    if (this.called === true) {
+      /* create another request */
+      const request = Object.assign(
+        new Request(this.url, this.method),
+        pick([
+          'domain',
+          '_events',
+          '_eventsCount',
+          '_maxListeners',
+          '_agent',
+          '_formData',
+          'method',
+          'url',
+          '_header',
+          'header',
+          'writable',
+          '_redirects',
+          '_maxRedirects',
+          'cookies',
+          'qs',
+          'qsRaw',
+          '_redirectList',
+          '_streamRequest'
+        ], this)
+      )
+      request.end(requestCallback)
+    } else {
+      this.end(requestCallback)
+    }
 
     return () => {
       /*
@@ -28,7 +64,7 @@ const observify = function(): Observable<*> {
 
 // TODO: add libdefs for superagent
 export default (superagent: any): void => {
-  superagent.Request.prototype.observify = observify
+  superagent.Request.prototype.observify = observify(superagent.Request)
 
   return void 0
 }


### PR DESCRIPTION
The former (resubscribability) is pretty self explanatory. The issue with the later was that `o.complete()` was called after `o.fail()` which is wrong.