### PR TITLE
Update `rxjs` to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
   },
   "homepage": "https://github.com/mrtnbroder/superagent-rxjs#readme",
   "dependencies": {
-    "rxjs": "^5.4.1",
-    "superagent": "^3.5.2"
+    "rxjs": "^6.3.3",
+    "superagent": "^3.8.3"
   },
   "devDependencies": {
     "ava": "0.20.0",
@@ -67,8 +67,8 @@
     "webpack": "3.0.0"
   },
   "peerDependencies": {
-    "rxjs": "^5",
-    "superagent": "^2 || ^3"
+    "rxjs": "^6",
+    "superagent": "^3"
   },
   "files": [
     "*.md",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 /* @flow */
 
-import type { Observable } from 'rxjs'
-import { Observable as O } from 'rxjs/Observable'
+import { Observable as O, type Observable } from 'rxjs'
 
 const observify = function(): Observable<*> {
   return O.create((o) => {


### PR DESCRIPTION
Update `rxjs` to v6 to remove console warnings. Everything works the same way, only needed to update import.